### PR TITLE
fix: use public subnet for ecs service network configuration

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -112,8 +112,8 @@ resource "aws_ecs_service" "api" {
 
   network_configuration {
     subnets = [
-      aws_subnet.private_a.id,
-      aws_subnet.private_b.id,
+      aws_subnet.public_a.id,
+      aws_subnet.public_b.id,
     ]
     security_groups  = [aws_security_group.ecs_service.id]
     assign_public_ip = true


### PR DESCRIPTION
Signed-off-by: Calvine Otieno <nyarangaotieno@gmail.com>